### PR TITLE
Update to v14.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -107,7 +107,6 @@ fi
   --enable-plugin \
   --enable-gold \
   --disable-nls \
-  --disable-bootstrap \
   --disable-multilib \
   --enable-long-long \
   --with-sysroot=${SYSROOT_DIR} \
@@ -116,4 +115,6 @@ fi
   --with-gxx-include-dir="${PREFIX}/lib/gcc/${TARGET}/${gcc_version}/include/c++" \
   "${GCC_CONFIGURE_OPTIONS[@]}"
 
-make -j${CPU_COUNT} || (cat ${TARGET}/libgomp/config.log; false)
+# Setting the CPU_COUNT=1 lets you see which job failed!
+#CPU_COUNT=1
+make -j${CPU_COUNT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,37 +1,37 @@
 triplet:
-  - x86_64-conda-linux-gnu
-  - powerpc64le-conda-linux-gnu
-  - aarch64-conda-linux-gnu
-  - x86_64-w64-mingw32
+  - x86_64-conda-linux-gnu      # [linux and x86_64]
+  - powerpc64le-conda-linux-gnu # [ppc64le]
+  - aarch64-conda-linux-gnu     # [linux and aarch64]
+  - x86_64-w64-mingw32          # [win]
 gcc_version:
-  - 15.1.0
-  - 14.3.0
-  - 13.4.0
+  - 15.1.0                      # [ANACONDA_ROCKET_ENABLE_GCC15]
+  - 14.3.0                      # [not ANACONDA_ROCKET_ENABLE_GCC13 and not ANACONDA_ROCKET_ENABLE_GCC15]
+  - 13.4.0                      # [ANACONDA_ROCKET_ENABLE_GCC13]
 gcc_maj_ver:
-  - 15
-  - 14
-  - 13
+  - 15                          # [ANACONDA_ROCKET_ENABLE_GCC15]
+  - 14                          # [not ANACONDA_ROCKET_ENABLE_GCC13 and not ANACONDA_ROCKET_ENABLE_GCC15]
+  - 13                          # [ANACONDA_ROCKET_ENABLE_GCC13]
 libgfortran_soname:
-  - 5
-  - 5
-  - 5
+  - 5                           # [ANACONDA_ROCKET_ENABLE_GCC15]
+  - 5                           # [not ANACONDA_ROCKET_ENABLE_GCC13 and not ANACONDA_ROCKET_ENABLE_GCC15]
+  - 5                           # [ANACONDA_ROCKET_ENABLE_GCC13]
 binutils_version:
-  - 2.40
+  - 2.44
 cross_target_platform:
-  - linux-64
-  - linux-ppc64le
-  - linux-aarch64
-  - win-64
+  - linux-64                    # [linux and x86_64]
+  - linux-ppc64le               # [ppc64le]
+  - linux-aarch64               # [linux and aarch64]
+  - win-64                      # [win]
 cross_target_stdlib_version:
-  - 2.17
-  - 2.17
-  - 2.17
-  - 12
+  - 2.28                        # [linux and x86_64]
+  - 2.28                        # [ppc64le]
+  - 2.28                        # [linux and aarch64]
+  - 12                          # [win]
 cross_target_stdlib:
-  - sysroot
-  - sysroot
-  - sysroot
-  - m2w64-sysroot
+  - sysroot                     # [linux and x86_64]
+  - sysroot                     # [ppc64le]
+  - sysroot                     # [linux and aarch64]
+  - m2w64-sysroot               # [win]
 # openmp versions
 openmp_ver:
   - 4.5
@@ -40,18 +40,10 @@ libgomp_ver:
 channel_sources:
   - conda-forge/label/sysroot-with-crypt,conda-forge
 # we could use stdlib("m2w64_c"), but this allows uniform use in setup_compiler.sh
-c_stdlib:          # [win]
-  - m2w64-sysroot  # [win]
-c_stdlib_version:  # [win]
-  - 12             # [win]
+c_stdlib:                       # [win]
+  - m2w64-sysroot               # [win]
+c_stdlib_version:               # [win]
+  - 12                          # [win]
 with_conda_specs:
   - true
   - false
-zip_keys:
-  - - cross_target_stdlib_version
-    - cross_target_stdlib
-    - triplet
-    - cross_target_platform
-  - - gcc_version
-    - gcc_maj_ver
-    - libgfortran_soname

--- a/recipe/install-gdb-pretty-printer.sh
+++ b/recipe/install-gdb-pretty-printer.sh
@@ -1,0 +1,10 @@
+set -e -x
+
+# install gcc's gdbhooks ...
+mkdir -p "$SP_DIR"/gcc
+cp $SRC_DIR/gcc/gcc/gdbhooks.py "$SP_DIR"/gcc/.
+
+# install libstdc++'s pretty printer support
+cp -r $SRC_DIR/gcc/libstdc++-v3/python/libstdcxx "$SP_DIR"/.
+
+exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,9 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.gz
+  - url:
+      - https://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.gz
+      - https://mirrors.ocf.berkeley.edu/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.gz
     sha256: 51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1   # [gcc_version == "15.1.0"]
     sha256: ace8b8b0dbfe6abfc22f821cb093e195aa5498b7ccf7cd23e4424b9f14afed22   # [gcc_version == "14.3.0"]
     sha256: bf0baf3e570c9c74c17c8201f0196c6924b4bd98c90e69d6b2ac0cd823f33bbc   # [gcc_version == "13.4.0"]
@@ -60,6 +62,7 @@ source:
 
 build:
   number: {{ build_num }}
+  skip: True  # [win]
   skip: true  # [not (linux or win) or (win and cross_target_platform != "win-64")]
   detect_binary_files_with_prefix: false
   ignore_run_exports_from:
@@ -83,6 +86,8 @@ outputs:
         - "*"
       ignore_run_exports_from:
         - {{ cross_target_stdlib }}_{{ cross_target_platform }}
+      overlinking_ignore_patterns:
+        - "*/lib/libgcc_s.so.*"
     requirements:
       build:
       host:
@@ -115,6 +120,8 @@ outputs:
         - "*"
       ignore_run_exports_from:
         - {{ cross_target_stdlib }}_{{ cross_target_platform }}
+      overlinking_ignore_patterns:
+        - "*/lib/libstdc++.so.*"
     requirements:
       build:
       host:
@@ -321,6 +328,7 @@ outputs:
     test:
       requires:
         - {{ cross_target_stdlib }}_{{ cross_target_platform }} {{ cross_target_stdlib_version }}
+        - strace_{{ cross_target_platform }}
       files:
         - tests
       commands:
@@ -338,7 +346,7 @@ outputs:
         {% if target_platform == cross_target_platform %}
         - ${CXX} tzdb-override.o -o tzdb-override && ./tzdb-override
         - ${CXX} tzdb.o -o tzdb && ./tzdb
-        - strace ./tzdb 2>&1 | grep ${CONDA_PREFIX}/lib/../share/zoneinfo/tzdata.zi
+        - $PREFIX/usr/bin/strace ./tzdb 2>&1 | grep ${CONDA_PREFIX}/lib/../share/zoneinfo/tzdata.zi
         # also test without any environment activation
         - unset PREFIX
         - unset CONDA_PREFIX
@@ -402,6 +410,7 @@ outputs:
     test:
       requires:
         - cmake >=3.11,<4  # [x86_64 or aarch64 or ppc64le]
+        - make
         - {{ cross_target_stdlib }}_{{ cross_target_platform }} {{ cross_target_stdlib_version }}
       commands:
         {% if cross_target_platform.startswith("linux-") %}
@@ -456,6 +465,8 @@ outputs:
       detect_binary_files_with_prefix: false
       missing_dso_whitelist:
         - "*"
+      overlinking_ignore_patterns:
+        - "lib/libstdc++.so.*"
     requirements:
       build:
       host:
@@ -463,7 +474,7 @@ outputs:
         - {{ pin_subpackage("libgcc", exact=True) }}
       run:
         - {{ pin_subpackage("libgcc", exact=True) }}
-      run_contrained:
+      run_constrained:
         # avoid installing incompatible version of old name for this output
         - libstdcxx-ng =={{ version }}=*_{{ build_num }}
     test:
@@ -485,6 +496,11 @@ outputs:
         - "*"
       run_exports:
         - libsanitizer {{ gcc_version }}
+      overlinking_ignore_patterns:
+        - "lib/libtsan.so.*"
+        - "lib/libasan.so.*"
+        - "lib/liblsan.so.*"
+        - "lib/libhwasan.so.*"
     requirements:
       build:
       host:
@@ -494,7 +510,7 @@ outputs:
         - libstdcxx >={{ gcc_version }}
     test:
       requires:
-        - {{ cross_target_stdlib }}_{{ cross_target_platform }}
+        - {{ cross_target_stdlib }}_{{ cross_target_platform }}  {{ cross_target_stdlib_version }}
         - gcc_impl_{{ cross_target_platform }}
       commands:
         - test -f ${PREFIX}/lib/libasan.so
@@ -548,6 +564,8 @@ outputs:
       missing_dso_whitelist:
         - "*"
       rpaths_patcher: patchelf
+      overlinking_ignore_patterns:
+        - "lib/libgcc_s.so.*"
     requirements:
       build:
       host:
@@ -612,6 +630,8 @@ outputs:
       detect_binary_files_with_prefix: false
       missing_dso_whitelist:
         - "*"
+      overlinking_ignore_patterns:
+        - "lib/libgfortran.so.*"
     requirements:
       build:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -735,6 +735,28 @@ outputs:
       license: GPL-3.0-only WITH GCC-exception-3.1
   {% endif %}
 
+  - name: gdb-pretty-printer
+    version: {{ gcc_version }}
+    script: install-gdb-pretty-printer.sh
+    build:
+      # skip until gdb 16.3 is on defaults (which is built against GCC 14.3.0)
+      skip: true
+      number: {{ build_num }}
+      ignore_run_exports:   # [linux]
+        - libstdcxx         # [linux]
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - gdb
+        - libstdcxx >={{ gcc_version }}
+    about:
+      summary: GNU Compiler Collection Python Pretty Printers
+      home: https://gcc.gnu.org/
+      license: GPL-3.0-only WITH GCC-exception-3.1
+
+
 about:
   summary: GNU Compiler Collection
   home: https://gcc.gnu.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
   - url:
       - https://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.gz
       - https://mirrors.ocf.berkeley.edu/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.gz
-    sha256: 51b9919ea69c980d7a381db95d4be27edf73b21254eb13d752a08003b4d013b1   # [gcc_version == "15.1.0"]
+    sha256: 7294d65cc1a0558cb815af0ca8c7763d86f7a31199794ede3f630c0d1b0a5723   # [gcc_version == "15.2.0"]
     sha256: ace8b8b0dbfe6abfc22f821cb093e195aa5498b7ccf7cd23e4424b9f14afed22   # [gcc_version == "14.3.0"]
     sha256: bf0baf3e570c9c74c17c8201f0196c6924b4bd98c90e69d6b2ac0cd823f33bbc   # [gcc_version == "13.4.0"]
     patches:
@@ -667,6 +667,27 @@ outputs:
       home: https://gcc.gnu.org/
       license: GPL-3.0-only WITH GCC-exception-3.1
 
+  - name: gdb-pretty-printer
+    version: {{ gcc_version }}
+    script: install-gdb-pretty-printer.sh
+    build:
+      # skip until gdb 16.3 is on defaults (which is built against GCC 14.3.0)
+      skip: true
+      number: {{ build_num }}
+      ignore_run_exports:   # [linux]
+        - libstdcxx         # [linux]
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - gdb >= 16.3
+        - libstdcxx >={{ gcc_version }}
+    about:
+      summary: GNU Compiler Collection Python Pretty Printers
+      home: https://gcc.gnu.org/
+      license: GPL-3.0-only WITH GCC-exception-3.1
+
   # compatibility outputs for previous naming of the runtime libraries
   # with "-ng" suffix; for windows the suffix had never been introduced
   {% if not cross_target_platform.startswith("win-") %}
@@ -734,27 +755,6 @@ outputs:
       home: https://gcc.gnu.org/
       license: GPL-3.0-only WITH GCC-exception-3.1
   {% endif %}
-
-  - name: gdb-pretty-printer
-    version: {{ gcc_version }}
-    script: install-gdb-pretty-printer.sh
-    build:
-      # skip until gdb 16.3 is on defaults (which is built against GCC 14.3.0)
-      skip: true
-      number: {{ build_num }}
-      ignore_run_exports:   # [linux]
-        - libstdcxx         # [linux]
-    requirements:
-      host:
-        - python
-      run:
-        - python
-        - gdb >= 16.3
-        - libstdcxx >={{ gcc_version }}
-    about:
-      summary: GNU Compiler Collection Python Pretty Printers
-      home: https://gcc.gnu.org/
-      license: GPL-3.0-only WITH GCC-exception-3.1
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -749,7 +749,7 @@ outputs:
         - python
       run:
         - python
-        - gdb
+        - gdb >= 16.3
         - libstdcxx >={{ gcc_version }}
     about:
       summary: GNU Compiler Collection Python Pretty Printers

--- a/recipe/setup_compiler.sh
+++ b/recipe/setup_compiler.sh
@@ -15,7 +15,7 @@ if [[ ! -d  $SRC_DIR/cf-compilers ]]; then
       )
     fi
     # Remove conda-forge/label/sysroot-with-crypt when GCC < 14 is dropped
-    conda create -p $SRC_DIR/cf-compilers -c conda-forge/label/sysroot-with-crypt -c conda-forge --yes --quiet \
+    conda create -p $SRC_DIR/cf-compilers --yes --quiet \
       "binutils_impl_${build_platform}" \
       "gcc_impl_${build_platform}" \
       "gxx_impl_${build_platform}" \
@@ -27,6 +27,7 @@ if [[ ! -d  $SRC_DIR/cf-compilers ]]; then
       "${c_stdlib}_${target_platform}=${c_stdlib_version}" \
       "binutils_impl_${cross_target_platform}=${binutils_version}" \
       "${cross_target_stdlib}_${cross_target_platform}=${cross_target_stdlib_version}" \
+      make \
       ${extra_pkgs[@]}
 fi
 


### PR DESCRIPTION
gcc 14.3.0

**Destination channel:** defaults

### Links

- [PKG-9694](https://anaconda.atlassian.net/browse/PKG-9694)
- [Upstream repository](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=c9cd41fba9ebd288c4f101e4b99da934bcb96a11)
- [Upstream changelog/diff](https://gcc.gnu.org/gcc-14/changes.html)

### Explanation of changes:

- Turned on bootstrapping by default to allow for the typical 3-stage compiler buildout
- Added preprocessors to disable cross-compilation in our CI
- Added a fallback source URL mirror since ftp.gnu.org likes to fail downloads in CI

### Testing

#### Downstream

Tested downstreams checking `libstdcxx=14.3.0` was used for a variety of packages: `aom` `capnproto` `opencv` `openjpeg` `qtbase` `vtk` `zstd` `python 3.11.14` [1]

#### Compilation

>[!NOTE]

Compilations using `11.2.0` compilers _in the presence of_ newer GCC libraries will result in a mix of `11.2.0` compilers and `14.3.0` (or later) libraries.


Tested various packages using `14.3.0` compilers for `aom` `capnproto` `pillow` `qtbase` `zstd` `zlib` `python 3.9.25` `python 3.14.0`

Tested various packages using `11.2.0` compilers with `14.3.0` libraries present for `capnproto` `pillow` `qtbase` `zstd` `zlib` `python 3.14.0`

>[!WARNING]

Compilations of _some_ packages using `11.2.0` compilers and `14.3.0` libraries may result in some overlinking errors:

```
  ERROR (aom,bin/aomdec): Needed DSO lib/libgcc_s.so.1 found in ['https://staging.continuum.io/pbp/fs/ctng-compilers-feedstock/pr0/80adb18/linux-aarch64::libgcc==14.3.0=hc18542e_4']
  ERROR (aom,bin/aomdec): .. but ['https://staging.continuum.io/pbp/fs/ctng-compilers-feedstock/pr0/80adb18/linux-aarch64::libgcc==14.3.0=hc18542e_4'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```

which may be a result of the use of staging channels.

[1] `python 3.x.y` might raises issues regarding a missing `libnsl.so.1` for non-recent `y`


[PKG-9694]: https://anaconda.atlassian.net/browse/PKG-9694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ